### PR TITLE
Remove a word used twice in FAQ #56

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
               ranging from ideas, music taste, content, political opinions, 
               and much more than you think. <br>
               By using LibreTube, you can freely watch and listen to content 
-              freely without the fear of prying eyes watching everything you are doing. 
+              without the fear of prying eyes watching everything you are doing. 
               Apart from that the Piped proxies can bypass geo restrictions, therefore
               LibreTube can be used in countries where YouTube is blocked.
             </p>


### PR DESCRIPTION
In the [index.html](https://github.com/libre-tube/libre-tube.github.io/blob/main/index.html), on lines 132-133, there's a sentence with the word `freely` used twice.

```
By using LibreTube, you can freely watch and listen to content 
freely without the fear of prying eyes watching everything you are doing. 
```

I suggest removing the latter.