### PR TITLE
Social link icons on about section - Z-index problem fix [Update style.css]

### DIFF
--- a/style.css
+++ b/style.css
@@ -155,6 +155,7 @@ section:not(:last-child) {
   column-gap: 2.5rem;
   border: 0.2rem solid var(--grey);
   border-radius: 3rem;
+  z-index: -1;
 }
 
 .social-links img {


### PR DESCRIPTION
On about section the social icons are going on top of the nav bar when scrolled. So the class "social-links"  (//div[@class='social-links']) has been modified and the z-index of that class has been set to -1 to make it go under properly.